### PR TITLE
Add a notebook for log analysis

### DIFF
--- a/query_predictor/jupyter_notebooks/README.md
+++ b/query_predictor/jupyter_notebooks/README.md
@@ -1,0 +1,20 @@
+# Jupyter Notebooks for the Query Predictor
+
+This folder contains Jupyter notebooks for exploratory analysis on Presto 
+request logs.
+
+
+## Files
+
+* `exploratory_analysis_presto_logs.ipynb`: Exploratory analysis on Presto logs.
+
+
+## Working with Notebooks
+
+Make sure you have installed the Jupyter notebook server locally. Afterward,
+
+1. `cd jupyter_notebooks`
+2. `jupyter notebook`
+
+The notebook server should start up and a browser window should open on your machine,
+allowing you to choose a notebook from this directory.

--- a/query_predictor/jupyter_notebooks/exploratory_analysis_presto_logs.ipynb
+++ b/query_predictor/jupyter_notebooks/exploratory_analysis_presto_logs.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exploratory Analysis of Presto Logs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a Jupyter notebook to implement an explorary analysis on Presto request logs.\n",
+    "\n",
+    "Before running the machine learning pipeline in the query predictor package, users can have a quick analysis on the logs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "pd.set_option('display.max_rows', 500)\n",
+    "pd.set_option('display.max_columns', 500)\n",
+    "pd.set_option('display.width', 1000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the dataset for analysis.\n",
+    "# The path may be changed for different datasets.\n",
+    "data = pd.read_csv('../datasets/data/presto-logs.csv')\n",
+    "columns = ['query_id', 'user_', 'principal', 'source', 'environment', 'catalog', 'query_state', \n",
+    "           'query', 'error_code_name', 'failure_type', 'peak_memory_bytes', 'cpu_time_ms', 'datehour']\n",
+    "data = data[columns]\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('starts from:', min(data['datehour']))\n",
+    "print('ends at:', max(data['datehour']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basic analysis on the logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "principal_df = data[data['principal'] == '-']\n",
+    "principal_df['source'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env_counts = data['environment'].value_counts()\n",
+    "print(env_counts)\n",
+    "env_counts[:5].plot.pie(y='environment')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_counts = data['source'].value_counts()\n",
+    "print(source_counts)\n",
+    "source_counts[:5].plot.pie(y='source')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat_counts = data['catalog'].value_counts()\n",
+    "print(cat_counts[:2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(data['user_'].unique()))\n",
+    "print(data['user_'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analysis of CPU and memory usages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['cpu_time_ms'].fillna(0)\n",
+    "data['peak_memory_bytes'].fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def category_cpu(row):\n",
+    "    if row.cpu_time_ms < 1000 * 30: # 30s\n",
+    "        return 0\n",
+    "    elif row.cpu_time_ms < 1000 * 60 * 5: # 5m\n",
+    "        return 1\n",
+    "    elif row.cpu_time_ms < 1000 * 60 * 60: # 1h\n",
+    "        return 2\n",
+    "    elif row.cpu_time_ms < 1000 * 60 * 60 * 5: # 5h\n",
+    "        return 3\n",
+    "    else:\n",
+    "        return 4\n",
+    "    \n",
+    "data['c_label'] = data.apply(category_cpu, axis = 1)\n",
+    "data.hist(column='c_label')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def category_memory(row):\n",
+    "    if row.peak_memory_bytes < 1024: # 1 MB\n",
+    "        return 0\n",
+    "    elif row.peak_memory_bytes < 1024 * 1024: # 1 GB\n",
+    "        return 1\n",
+    "    elif row.peak_memory_bytes < 1024 * 1024 * 1024: # 1 TB\n",
+    "        return 2\n",
+    "    else:\n",
+    "        return 3\n",
+    "\n",
+    "data['m_label'] = data.apply(category_memory, axis = 1)\n",
+    "data.hist(column='m_label')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analysis of failed queries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state_counts = data['query_state'].value_counts()\n",
+    "print(state_counts)\n",
+    "total_count = state_counts[0] + state_counts[1]\n",
+    "print('Success:', state_counts[0] / total_count)\n",
+    "print('Failure:', state_counts[1] / total_count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['error_code_name'].value_counts()[:10]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a Jupyter notebook for Presto log analysis. Typically, the notebook could be run before running the machine learning pipeline for query resource usage prediction to get some basic sense of historical Presto queries.
